### PR TITLE
execute CheckForNewVersion after parsing flags

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/zendesk/goship/color"
-	"github.com/zendesk/goship/config"
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/zendesk/goship/color"
+	"github.com/zendesk/goship/config"
+	"github.com/zendesk/goship/version"
 )
 
 var (
@@ -35,6 +36,8 @@ func initRootFlags(cmd *cobra.Command, args []string) {
 	if forceUncache {
 		config.GlobalConfig.CacheValidity = 0
 	}
+
+	version.CheckForNewVersion()
 }
 
 // Execute cobra
@@ -68,7 +71,6 @@ func init() {
 	viper.BindPFlag("cache_file_prefix", RootCmd.PersistentFlags().Lookup("cache-file-prefix"))
 	viper.BindPFlag("cache_validity", RootCmd.PersistentFlags().Lookup("cache-validity"))
 	viper.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
-
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -99,6 +101,6 @@ func initConfig() {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		color.PrintRed(fmt.Sprintf("Error while reading file %s", ConfigFile))
+		color.PrintRed(fmt.Sprintf("Error while reading file %s\n", ConfigFile))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"github.com/zendesk/goship/cmd"
-	"github.com/zendesk/goship/version"
 )
 
 func main() {
-	version.CheckForNewVersion()
 	cmd.Execute()
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 func CheckForNewVersion() {
 
 	if config.GlobalConfig.Verbose {
-		color.PrintYellow("Checking for newest version temporarily disabled")
+		color.PrintYellow("Checking for newest version temporarily disabled\n")
 	}
 	return
 }


### PR DESCRIPTION
function version.CheckForNewVersion() is executed before global flags are
parsed, because of that config.GlobalConfig.Verbose is always false
(default) and the check is actually never invoked (i know it is disabled atm,
but still;)

i've also:
- sorted imports in cmd/cli.go
- added new lines to avoid such outputs:
  '...version temporarily disabledVersion: 1.0.0'