### PR TITLE
AwsEc2Cache Refresh() fix

### DIFF
--- a/cache/aws_ec2.go
+++ b/cache/aws_ec2.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/zendesk/goship/config"
 	"github.com/zendesk/goship/providers"
 	"github.com/zendesk/goship/resources"
@@ -67,12 +66,10 @@ func (g *AwsEc2Cache) Refresh(force bool) (err error) {
 		g.Read()
 		return nil
 	}
-	config := aws.Config{}
 
-	provider := providers.AwsEc2Provider{AwsConfig: config, AwsRegion: g.Provider.AwsRegion, AwsProfileName: g.Provider.AwsProfileName}
-	provider.Init()
+	g.Provider.Init()
 
-	result, err := provider.GetResources()
+	result, err := g.Provider.GetResources()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently Refresh() function creates new AwsEc2Provider each time it is
executed. Morover it sets AwsConfig field to an "empty" aws.Config{}
causing aws.Config.Region to be <nil>. This forces REGION to be taken
from ~/.aws/config profile instead of .goship.yaml config file.

It could be fixed by:
"AwsConfig: config" -> "AwsConfig: g.Provider.AwsConfig":
```
-       config := aws.Config{}
-       provider := providers.AwsEc2Provider{AwsConfig: config, AwsRegion: g.Provider.AwsRegion, AwsProfileName: g.Provider.AwsProfileName}
+       provider := providers.AwsEc2Provider{AwsConfig: g.Provider.AwsConfig, AwsRegion: g.Provider.AwsRegion, AwsProfileName: g.Provider.AwsProfileName}
```
or (imo) even better to simply reuse existing provider without creating
a new struct. And that's what I'm suggesting in this commit.