### PR TITLE
Fix linter errors

### DIFF
--- a/cache/aws_ec2.go
+++ b/cache/aws_ec2.go
@@ -62,12 +62,15 @@ func (g *AwsEc2Cache) Len() int {
 
 // Refresh refreshes resources
 func (g *AwsEc2Cache) Refresh(force bool) (refreshed bool, err error) {
-	if g.cacheOutdated() == false && force == false {
-		g.Read()
-		return false, nil
+	if !g.cacheOutdated() && !force {
+		err = g.Read()
+		return false, err
 	}
 
-	g.Provider.Init()
+	err = g.Provider.Init()
+	if err != nil {
+		return false, err
+	}
 
 	result, err := g.Provider.GetResources()
 	if err != nil {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -66,14 +66,14 @@ func init() {
 	RootCmd.PersistentFlags().StringP("cache-file-prefix", "", "goship_cache_", "Cache file prefix")
 	RootCmd.PersistentFlags().UintP("cache-validity", "t", 300, "Cache validity in seconds")
 
-	viper.BindPFlag("username", RootCmd.PersistentFlags().Lookup("username"))
-	viper.BindPFlag("ssh-command", RootCmd.PersistentFlags().Lookup("ssh-command"))
-	viper.BindPFlag("use_private_network", RootCmd.PersistentFlags().Lookup("use-private-network"))
-	viper.BindPFlag("use_dns", RootCmd.PersistentFlags().Lookup("use-dns"))
-	viper.BindPFlag("cache_directory", RootCmd.PersistentFlags().Lookup("cache-directory"))
-	viper.BindPFlag("cache_file_prefix", RootCmd.PersistentFlags().Lookup("cache-file-prefix"))
-	viper.BindPFlag("cache_validity", RootCmd.PersistentFlags().Lookup("cache-validity"))
-	viper.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
+	_ = viper.BindPFlag("username", RootCmd.PersistentFlags().Lookup("username"))
+	_ = viper.BindPFlag("ssh-command", RootCmd.PersistentFlags().Lookup("ssh-command"))
+	_ = viper.BindPFlag("use_private_network", RootCmd.PersistentFlags().Lookup("use-private-network"))
+	_ = viper.BindPFlag("use_dns", RootCmd.PersistentFlags().Lookup("use-dns"))
+	_ = viper.BindPFlag("cache_directory", RootCmd.PersistentFlags().Lookup("cache-directory"))
+	_ = viper.BindPFlag("cache_file_prefix", RootCmd.PersistentFlags().Lookup("cache-file-prefix"))
+	_ = viper.BindPFlag("cache_validity", RootCmd.PersistentFlags().Lookup("cache-validity"))
+	_ = viper.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -17,7 +17,6 @@ var findCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(findCmd)
-
 }
 
 func findCmdFunc(cmd *cobra.Command, args []string) {
@@ -26,7 +25,7 @@ func findCmdFunc(cmd *cobra.Command, args []string) {
 	output := filterCacheList(&cacheList, cmd.Annotations)
 
 	for _, r := range output {
-		fmt.Printf(r.RenderLongOutput())
+		fmt.Print(r.RenderLongOutput())
 	}
 
 }

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -35,7 +35,7 @@ func validateScpCmdFunc(cmd *cobra.Command, args []string) error {
 		cmd.Annotations["local_path"] = cmd.Annotations["copy_from"]
 		cmd.Annotations["direction"] = "to"
 	} else {
-		return errors.New("None of paths is a remote path")
+		return errors.New("none of paths is a remote path")
 	}
 	return nil
 }
@@ -89,6 +89,9 @@ func scpCmdFunc(cmd *cobra.Command, args []string) {
 		Cmd:    baseCommand,
 		Env:    env,
 	}
-	comm.Exec()
-
+	err = comm.Exec()
+	if err != nil {
+		fmt.Printf("Error while executing command %s", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -84,5 +84,9 @@ func sshCmdFunc(cmd *cobra.Command, args []string) {
 		Cmd:    sshCommandWithArgs,
 		Env:    env,
 	}
-	comm.Exec()
+	err = comm.Exec()
+	if err != nil {
+		fmt.Printf("Error while executing command %s", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -88,6 +88,10 @@ func tunnelCmdFunc(cmd *cobra.Command, args []string) {
 		Cmd:    tunnelCommand,
 		Env:    env,
 	}
-	comm.Exec()
+	err = comm.Exec()
+	if err != nil {
+		fmt.Printf("Error while executing command %s", err)
+		os.Exit(1)
+	}
 
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -71,10 +71,13 @@ func getCacheList() cache.GlobalCacheList {
 
 	cacheList := initCaches()
 	if len(cacheList) == 0 {
-		color.PrintYellow(fmt.Sprintf("WARNING: No valid providers configured. Please refer to the documentation in order to configure it.\n"))
+		color.PrintYellow(fmt.Sprint("WARNING: No valid providers configured. Please refer to the documentation in order to configure it.\n"))
 	}
 	refreshStart := time.Now()
-	cacheList.RefreshInParallel(false)
+	err := cacheList.RefreshInParallel(false)
+	if err != nil {
+		color.PrintRed(fmt.Sprintf("Error while getting cache list: %s", err.Error()))
+	}
 	refreshElapsed := time.Since(refreshStart)
 
 	if config.GlobalConfig.Verbose {
@@ -88,7 +91,7 @@ func filterCacheList(cacheList *cache.GlobalCacheList, criteria map[string]strin
 	for _, c := range *cacheList {
 		for _, r := range c.Resources() {
 			if env, exists := criteria["environment"]; exists {
-				if strings.Contains(r.GetTag("environment"), env) == false {
+				if !strings.Contains(r.GetTag("environment"), env) {
 					continue
 				}
 			}
@@ -112,7 +115,7 @@ func filterCacheList(cacheList *cache.GlobalCacheList, criteria map[string]strin
 func validatePortNumber(portNumber string) error {
 	_, err := strconv.Atoi(portNumber)
 	if err != nil {
-		return fmt.Errorf("Unknown port value: %s", portNumber)
+		return fmt.Errorf("unknown port value: %s", portNumber)
 	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,7 +17,7 @@ func ChooseFromList(resourcesList []resources.Resource) (resources.Resource, err
 	} else if len(resourcesList) > 1 {
 		for i, r := range resourcesList {
 			fmt.Printf("%d. ", i+1)
-			fmt.Printf(r.RenderShortOutput())
+			fmt.Print(r.RenderShortOutput())
 		}
 
 		reader := bufio.NewReader(os.Stdin)
@@ -25,10 +25,10 @@ func ChooseFromList(resourcesList []resources.Resource) (resources.Resource, err
 		choose, _ := reader.ReadString('\n')
 		idx, err := strconv.Atoi(strings.TrimSuffix(choose, "\n"))
 		if len(resourcesList)+1 <= idx || idx < 1 || err != nil {
-			return nil, fmt.Errorf("Unknown choose %s", choose)
+			return nil, fmt.Errorf("unknown choose %s", choose)
 		}
 		return resourcesList[idx-1], nil
 	} else {
-		return nil, fmt.Errorf("No possible elements to display")
+		return nil, fmt.Errorf("no possible elements to display")
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -32,5 +32,4 @@ func CheckForNewVersion() {
 	if result.Outdated && config.GlobalConfig.Verbose {
 		color.PrintYellow(fmt.Sprintf("Newer version (%s) available! Checkout project repository to upgrade to the newest version.\n", result.Current))
 	}
-	return
 }


### PR DESCRIPTION
As we're switching to `golangci-lint`, some linter errors are being fixed.