### PR TITLE
Add preinit_hook command for provider

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,5 +10,6 @@
 #    aws.ec2:
 #        - profile: production
 #          regions: [us-east-1]
+#          preinit_hook: /usr/bin/saml2aws ...
 #        - profile: sandbox
 #          regions: [eu-west-1]

--- a/providers/aws_ec2.go
+++ b/providers/aws_ec2.go
@@ -2,6 +2,9 @@ package providers
 
 import (
 	"fmt"
+	"github.com/zendesk/goship/config"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -22,7 +25,22 @@ type AwsEc2Provider struct {
 // InitAwsEc2ProvidersFromCfg creates AwsEc2Provider list based on config sections
 func InitAwsEc2ProvidersFromCfg(cfg map[interface{}]interface{}) (p []*AwsEc2Provider, err error) {
 	profile := cfg["profile"].(string)
-
+	if _, ok := cfg["preinit_hook"]; ok {
+		if config.GlobalConfig.Verbose {
+			fmt.Printf("Executing preinit hook: %s\n", cfg["preinit_hook"])
+		}
+		command := strings.Split(cfg["preinit_hook"].(string), " ")
+		cmd := exec.Command(
+			command[0], command[1:]...,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			color.PrintRed(fmt.Sprintf("Error while running the preinit `%s` hook: %s\n", cfg["preinit_hook"], err.Error()))
+		}
+	}
 	for _, region := range cfg["regions"].([]interface{}) {
 		provider := &AwsEc2Provider{
 			AwsRegion:      region.(string),


### PR DESCRIPTION
Add `preinit_hook` configuration option to provider block to enable running custom command before initialising the cache.