### PR TITLE
Host can be chosen by IP

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -23,7 +24,13 @@ func ChooseFromList(resourcesList []resources.Resource) (resources.Resource, err
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Choose your ship: ")
 		choose, _ := reader.ReadString('\n')
-		idx, err := strconv.Atoi(strings.TrimSuffix(choose, "\n"))
+		choose = strings.TrimSuffix(choose, "\n")
+
+		if choosenIP(choose) {
+			return findResourceByIP(choose, resourcesList)
+		}
+
+		idx, err := strconv.Atoi(choose)
 		if len(resourcesList)+1 <= idx || idx < 1 || err != nil {
 			return nil, fmt.Errorf("unknown choose %s", choose)
 		}
@@ -31,4 +38,18 @@ func ChooseFromList(resourcesList []resources.Resource) (resources.Resource, err
 	} else {
 		return nil, fmt.Errorf("no possible elements to display")
 	}
+}
+
+func choosenIP(id string) bool {
+	ip := net.ParseIP(id)
+	return ip != nil
+}
+
+func findResourceByIP(ip string, resourcesList []resources.Resource) (resources.Resource, error) {
+	for _, v := range resourcesList {
+		if v.ConnectIdentifier(true, false) == ip {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find resource with specified IP")
 }


### PR DESCRIPTION
Initially only ID of the instance could be used when choosing it from list. In some cases, however, it is more convenient to use IP address of the instance. 
With this change both methods can be used - when we provide IP address the list of instances will be scanned for the instance with this private IP and used for connection.